### PR TITLE
Adjust shrinker tests

### DIFF
--- a/gson/src/main/resources/META-INF/proguard/gson.pro
+++ b/gson/src/main/resources/META-INF/proguard/gson.pro
@@ -59,8 +59,9 @@
   <init>();
 }
 
-# If a class is used in some way by the application, and has fields annotated with @SerializedName
-# and a no-args constructor, keep those fields and the constructor
+# If a class is used in some way by the application and has fields annotated with @SerializedName,
+# keep those fields and the constructors of the class
+# For convenience this also matches classes without no-args constructor, in which case Gson uses JDK Unsafe
 # Based on https://issuetracker.google.com/issues/150189783#comment11
 # See also https://github.com/google/gson/pull/2420#discussion_r1241813541 for a more detailed explanation
 -if class *

--- a/shrinker-test/common.pro
+++ b/shrinker-test/common.pro
@@ -15,7 +15,7 @@
 -keep class com.example.Main {
   public static void runTests(...);
 }
--keep class com.example.DefaultConstructorMain {
+-keep class com.example.NoSerializedNameMain {
   public static java.lang.String runTest();
   public static java.lang.String runTestNoJdkUnsafe();
   public static java.lang.String runTestNoDefaultConstructor();
@@ -36,13 +36,5 @@
   ** f;
 }
 -keepclassmembernames class com.example.ClassWithVersionAnnotations {
-  <fields>;
-}
-
-
--keepclassmembernames class com.example.DefaultConstructorMain$TestClass {
-  <fields>;
-}
--keepclassmembernames class com.example.DefaultConstructorMain$TestClassNotAbstract {
   <fields>;
 }

--- a/shrinker-test/proguard.pro
+++ b/shrinker-test/proguard.pro
@@ -3,6 +3,15 @@
 
 ### ProGuard specific rules
 
--keep class com.example.DefaultConstructorMain$TestClassWithoutDefaultConstructor {
+# Unlike R8, ProGuard does not perform aggressive optimization which makes classes abstract,
+# therefore for ProGuard can successfully perform deserialization, and for that need to
+# preserve the field names
+-keepclassmembernames class com.example.NoSerializedNameMain$TestClass {
+  <fields>;
+}
+-keepclassmembernames class com.example.NoSerializedNameMain$TestClassNotAbstract {
+  <fields>;
+}
+-keepclassmembernames class com.example.NoSerializedNameMain$TestClassWithoutDefaultConstructor {
   <fields>;
 }

--- a/shrinker-test/r8.pro
+++ b/shrinker-test/r8.pro
@@ -10,11 +10,11 @@
 -keep,allowshrinking,allowoptimization,allowobfuscation,allowaccessmodification class com.example.GenericClasses$GenericUsingGenericClass
 
 # Don't obfuscate class name, to check it in exception message
--keep,allowshrinking,allowoptimization class com.example.DefaultConstructorMain$TestClass
--keep,allowshrinking,allowoptimization class com.example.DefaultConstructorMain$TestClassWithoutDefaultConstructor
+-keep,allowshrinking,allowoptimization class com.example.NoSerializedNameMain$TestClass
+-keep,allowshrinking,allowoptimization class com.example.NoSerializedNameMain$TestClassWithoutDefaultConstructor
 
 # This rule has the side-effect that R8 still removes the no-args constructor, but does not make the class abstract
--keep class com.example.DefaultConstructorMain$TestClassNotAbstract {
+-keep class com.example.NoSerializedNameMain$TestClassNotAbstract {
   @com.google.gson.annotations.SerializedName <fields>;
 }
 

--- a/shrinker-test/src/main/java/com/example/ClassWithDefaultConstructor.java
+++ b/shrinker-test/src/main/java/com/example/ClassWithDefaultConstructor.java
@@ -2,6 +2,10 @@ package com.example;
 
 import com.google.gson.annotations.SerializedName;
 
+/**
+ * Class with no-args default constructor and with field annotated with
+ * {@link SerializedName}.
+ */
 public class ClassWithDefaultConstructor {
   @SerializedName("myField")
   public int i;

--- a/shrinker-test/src/main/java/com/example/ClassWithoutDefaultConstructor.java
+++ b/shrinker-test/src/main/java/com/example/ClassWithoutDefaultConstructor.java
@@ -1,0 +1,17 @@
+package com.example;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Class without no-args default constructor, but with field annotated with
+ * {@link SerializedName}.
+ */
+public class ClassWithoutDefaultConstructor {
+  @SerializedName("myField")
+  public int i;
+
+  // Specify explicit constructor with args to remove implicit no-args default constructor
+  public ClassWithoutDefaultConstructor(int i) {
+    this.i = i;
+  }
+}

--- a/shrinker-test/src/main/java/com/example/Main.java
+++ b/shrinker-test/src/main/java/com/example/Main.java
@@ -32,6 +32,7 @@ public class Main {
     testNamedFields(outputConsumer);
     testSerializedName(outputConsumer);
 
+    testNoDefaultConstructor(outputConsumer);
     testNoJdkUnsafe(outputConsumer);
 
     testEnum(outputConsumer);
@@ -85,6 +86,16 @@ public class Main {
     TestExecutor.run(outputConsumer, "Write: SerializedName", () -> toJson(gson, new ClassWithSerializedName(2)));
     TestExecutor.run(outputConsumer, "Read: SerializedName", () -> {
       ClassWithSerializedName deserialized = fromJson(gson, "{\"myField\": 3}", ClassWithSerializedName.class);
+      return Integer.toString(deserialized.i);
+    });
+  }
+
+  private static void testNoDefaultConstructor(BiConsumer<String, String> outputConsumer) {
+    Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    TestExecutor.run(outputConsumer, "Write: No default constructor", () -> toJson(gson, new ClassWithoutDefaultConstructor(2)));
+    // This most likely relies on JDK Unsafe (unless the shrinker rewrites the constructor in some way)
+    TestExecutor.run(outputConsumer, "Read: No default constructor", () -> {
+      ClassWithoutDefaultConstructor deserialized = fromJson(gson, "{\"myField\": 3}", ClassWithoutDefaultConstructor.class);
       return Integer.toString(deserialized.i);
     });
   }

--- a/shrinker-test/src/main/java/com/example/NoSerializedNameMain.java
+++ b/shrinker-test/src/main/java/com/example/NoSerializedNameMain.java
@@ -4,32 +4,32 @@ import static com.example.TestExecutor.same;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.annotations.SerializedName;
 
-public class DefaultConstructorMain {
+/**
+ * Covers cases of classes which don't use {@code @SerializedName} on their fields, and are
+ * therefore not matched by the default {@code gson.pro} rules.
+ */
+public class NoSerializedNameMain {
   static class TestClass {
     public String s;
   }
 
-  // R8 rule for this class still removes no-args constructor, but doesn't make class abstract
+  // R8 test rule in r8.pro for this class still removes no-args constructor, but doesn't make class abstract
   static class TestClassNotAbstract {
     public String s;
   }
 
-  // Current Gson ProGuard rules only keep default constructor (and only then prevent R8 from
-  // making class abstract); other constructors are ignored to suggest to user adding default
-  // constructor instead of implicitly relying on JDK Unsafe
   static class TestClassWithoutDefaultConstructor {
-    // No @SerializedName annotation to avoid matching the consumer rules from gson.pro.
     public String s;
 
+    // Specify explicit constructor with args to remove implicit no-args default constructor
     public TestClassWithoutDefaultConstructor(String s) {
       this.s = s;
     }
   }
 
   /**
-   * Main entrypoint, called by {@code ShrinkingIT.testDefaultConstructor()}.
+   * Main entrypoint, called by {@code ShrinkingIT.testNoSerializedName_DefaultConstructor()}.
    */
   public static String runTest() {
     TestClass deserialized = new Gson().fromJson("{\"s\":\"value\"}", same(TestClass.class));
@@ -37,7 +37,7 @@ public class DefaultConstructorMain {
   }
 
   /**
-   * Main entrypoint, called by {@code ShrinkingIT.testDefaultConstructorNoJdkUnsafe()}.
+   * Main entrypoint, called by {@code ShrinkingIT.testNoSerializedName_DefaultConstructorNoJdkUnsafe()}.
    */
   public static String runTestNoJdkUnsafe() {
     Gson gson = new GsonBuilder().disableJdkUnsafe().create();
@@ -46,7 +46,7 @@ public class DefaultConstructorMain {
   }
 
   /**
-   * Main entrypoint, called by {@code ShrinkingIT.testNoDefaultConstructor()}.
+   * Main entrypoint, called by {@code ShrinkingIT.testNoSerializedName_NoDefaultConstructor()}.
    */
   public static String runTestNoDefaultConstructor() {
     TestClassWithoutDefaultConstructor deserialized = new Gson().fromJson("{\"s\":\"value\"}", same(TestClassWithoutDefaultConstructor.class));

--- a/shrinker-test/src/test/java/com/google/gson/it/ShrinkingIT.java
+++ b/shrinker-test/src/test/java/com/google/gson/it/ShrinkingIT.java
@@ -127,6 +127,14 @@ public class ShrinkingIT {
         "Read: SerializedName",
         "3",
         "===",
+        "Write: No default constructor",
+        "{",
+        "  \"myField\": 2",
+        "}",
+        "===",
+        "Read: No default constructor",
+        "3",
+        "===",
         "Read: No JDK Unsafe; initial constructor value",
         "-3",
         "===",
@@ -181,8 +189,8 @@ public class ShrinkingIT {
   }
 
   @Test
-  public void testDefaultConstructor() throws Exception {
-    runTest("com.example.DefaultConstructorMain", c -> {
+  public void testNoSerializedName_DefaultConstructor() throws Exception {
+    runTest("com.example.NoSerializedNameMain", c -> {
       Method m = c.getMethod("runTest");
 
       if (jarToTest.equals(PROGUARD_RESULT_PATH)) {
@@ -193,7 +201,7 @@ public class ShrinkingIT {
         Exception e = assertThrows(InvocationTargetException.class, () -> m.invoke(null));
         assertThat(e).hasCauseThat().hasMessageThat().isEqualTo(
             "Abstract classes can't be instantiated! Adjust the R8 configuration or register an InstanceCreator"
-            + " or a TypeAdapter for this type. Class name: com.example.DefaultConstructorMain$TestClass"
+            + " or a TypeAdapter for this type. Class name: com.example.NoSerializedNameMain$TestClass"
             + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#r8-abstract-class"
         );
       }
@@ -201,8 +209,8 @@ public class ShrinkingIT {
   }
 
   @Test
-  public void testDefaultConstructorNoJdkUnsafe() throws Exception {
-    runTest("com.example.DefaultConstructorMain", c -> {
+  public void testNoSerializedName_DefaultConstructorNoJdkUnsafe() throws Exception {
+    runTest("com.example.NoSerializedNameMain", c -> {
       Method m = c.getMethod("runTestNoJdkUnsafe");
 
       if (jarToTest.equals(PROGUARD_RESULT_PATH)) {
@@ -212,7 +220,7 @@ public class ShrinkingIT {
         // R8 performs more aggressive optimizations
         Exception e = assertThrows(InvocationTargetException.class, () -> m.invoke(null));
         assertThat(e).hasCauseThat().hasMessageThat().isEqualTo(
-            "Unable to create instance of class com.example.DefaultConstructorMain$TestClassNotAbstract;"
+            "Unable to create instance of class com.example.NoSerializedNameMain$TestClassNotAbstract;"
             + " usage of JDK Unsafe is disabled. Registering an InstanceCreator or a TypeAdapter for this type,"
             + " adding a no-args constructor, or enabling usage of JDK Unsafe may fix this problem. Or adjust"
             + " your R8 configuration to keep the no-args constructor of the class."
@@ -222,8 +230,8 @@ public class ShrinkingIT {
   }
 
   @Test
-  public void testNoDefaultConstructor() throws Exception {
-    runTest("com.example.DefaultConstructorMain", c -> {
+  public void testNoSerializedName_NoDefaultConstructor() throws Exception {
+    runTest("com.example.NoSerializedNameMain", c -> {
       Method m = c.getMethod("runTestNoDefaultConstructor");
 
       if (jarToTest.equals(PROGUARD_RESULT_PATH)) {
@@ -234,7 +242,7 @@ public class ShrinkingIT {
         Exception e = assertThrows(InvocationTargetException.class, () -> m.invoke(null));
         assertThat(e).hasCauseThat().hasMessageThat().isEqualTo(
             "Abstract classes can't be instantiated! Adjust the R8 configuration or register an InstanceCreator"
-            + " or a TypeAdapter for this type. Class name: com.example.DefaultConstructorMain$TestClassWithoutDefaultConstructor"
+            + " or a TypeAdapter for this type. Class name: com.example.NoSerializedNameMain$TestClassWithoutDefaultConstructor"
             + "\nSee https://github.com/google/gson/blob/main/Troubleshooting.md#r8-abstract-class"
         );
       }


### PR DESCRIPTION
Tries to address the review comments I made in #2448.
This also renames `DefaultConstructorMain` to `NoSerializedNameMain` because the main purpose seems to be now covering classes without `@SerializedName` usage. Though feel free to rename it if you can think of a better name for it.

Please let me know if you want anything changed, or if you want directly perform the changes yourself.